### PR TITLE
Block app popup for google amp links

### DIFF
--- a/hideRedditAds.css
+++ b/hideRedditAds.css
@@ -17,3 +17,7 @@
 .XPromoPopup {
     display: none;
 }
+
+div.AppSelectorModal__body.new_animation_blue_button[\[hidden\]="isUpsellHidden != 0"] {
+    display: none;
+}

--- a/hideRedditAds.css
+++ b/hideRedditAds.css
@@ -18,6 +18,6 @@
     display: none;
 }
 
-div.AppSelectorModal__body.new_animation_blue_button[\[hidden\]="isUpsellHidden != 0"] {
+body[amp-x-app_selector_iterations_v2_2=new_animation_blue_button] div.AppSelectorModal__body.new_animation_blue_button[\[hidden\]="isUpsellHidden != 0"] {
     display: none;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
   "content_scripts": [
     {
       "matches": ["*://*.reddit.com/*"],
-      "css": ["hideRedditAds.css"]
+      "css": ["hideRedditAds.css"],
+      "all_frames": true
     }
   ]
 

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,11 @@
 
   "content_scripts": [
     {
-      "matches": ["*://*.reddit.com/*", "*://*.google.com/amp/s/amp.reddit.com/*"],
+      "matches": [
+        "*://*.reddit.com/*", 
+        "*://*.google.com/amp/s/amp.reddit.com/*", 
+        "*://amp-reddit-com.cdn.ampproject.org/v/s/amp.reddit.com/*"
+      ],
       "css": ["hideRedditAds.css"],
       "all_frames": true
     }

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
 
   "content_scripts": [
     {
-      "matches": ["*://*.reddit.com/*"],
+      "matches": ["*://*.reddit.com/*", "*://*.google.com/amp/s/amp.reddit.com/*"],
       "css": ["hideRedditAds.css"],
       "all_frames": true
     }


### PR DESCRIPTION
This hides the 'See reddit in...' popup from google links.

Adds a new (very specific) css rule for another popup. And adds support for Google Amp links that show instead of reddit links when viewing results from a google search.